### PR TITLE
feat: add panning to canvas

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,9 +7,11 @@ html,
 body {
   height: 100%;
   width: 100%;
+  background: #666
 }
 
 #whiteboard {
   cursor: crosshair;
   background-color: #ffffff;
+  touch-action: none;
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -6,13 +6,32 @@ type Coordinates = {
   y: number;
 }
 
+type Stroke = {
+  points: Coordinates[];
+  color: string | CanvasGradient | CanvasPattern;
+  width: number;
+};
+
+enum Mode {
+  IDLE = "idle",
+  DRAWING = "drawing",
+  PANNING = "panning",
+}
+
 class Whiteboard {
   private canvas: HTMLCanvasElement;
   private ctx: CanvasRenderingContext2D;
-  private isDrawing: boolean = false;
-  private lastX: number = 0;
-  private lastY: number = 0;
+  private mode: Mode.IDLE | Mode.DRAWING | Mode.PANNING = Mode.IDLE;
+
+  // drawing
   private hasMoved: boolean = false;
+
+  // panning
+  private panStart: Coordinates = { x: 0, y: 0 };
+  private offset: Coordinates = { x: 0, y: 0 };
+  private lastOffset: Coordinates = { x: 0, y: 0 };
+  private strokes: Stroke[] = [];
+  private currentStroke: Stroke | null = null;
 
   constructor(canvasId: string) {
     this.canvas = document.getElementById(canvasId) as HTMLCanvasElement;
@@ -38,65 +57,142 @@ class Whiteboard {
     this.canvas.addEventListener('mouseup', this.stopDrawing.bind(this));
     this.canvas.addEventListener('mouseout', this.stopDrawing.bind(this));
 
-    this.canvas.addEventListener('touchstart', this.startDrawing.bind(this));
-    this.canvas.addEventListener('touchmove', this.draw.bind(this));
-    this.canvas.addEventListener('touchend', this.stopDrawing.bind(this));
-    this.canvas.addEventListener('touchcancel', this.stopDrawing.bind(this));
+    this.canvas.addEventListener('touchstart', this.handleTouchStart.bind(this));
+    this.canvas.addEventListener('touchmove', this.handleTouchMove.bind(this));
+    this.canvas.addEventListener('touchend', this.handleTouchEnd.bind(this));
+    this.canvas.addEventListener('touchcancel', this.handleTouchEnd.bind(this));
   }
 
+  // ************* TOUCH EVENTS *************
+  private handleTouchStart(e: TouchEvent): void {
+    console.log('e.touches.length :>> ', e.touches.length);
+    console.log('this.mode :>> ', this.mode);
+    console.log('this.hasMoved :>> ', this.hasMoved);
+
+    if (e.touches.length === 2) {
+      this.startPanning(e);
+    } else if (e.touches.length === 1) {
+      this.startDrawing(e);
+    }
+  }
+
+  private handleTouchMove(e: TouchEvent): void {
+    if (this.mode === Mode.PANNING && e.touches.length === 2) {
+      this.continuePanning(e);
+    } else if (this.mode === Mode.DRAWING && e.touches.length === 1) {
+      this.draw(e);
+    }
+  }
+
+  private handleTouchEnd(e: TouchEvent): void {
+    if (this.mode === Mode.PANNING && e.touches.length < 2) {
+      this.stopPanning();
+    } else if (this.mode === Mode.DRAWING && e.touches.length === 0) {
+      this.stopDrawing(e);
+    }
+  }
+  
+  // ************* PANNING *************
+  private startPanning(e: TouchEvent): void {
+    if (this.mode === Mode.DRAWING) {
+      if (this.hasMoved) {
+        this.stopDrawing(e)
+      } else {
+        // We only keep the current stroke if we've moved - this is to stop phantom dots
+        this.currentStroke = null;
+        this.redraw();
+      }
+    }
+    this.mode = Mode.PANNING;
+    this.panStart = this.getAverageCoordinates(e);
+    this.lastOffset = this.offset;
+  }
+
+  private continuePanning(e: TouchEvent): void {
+    const currentCoords = this.getAverageCoordinates(e);
+    this.offset = {
+      x: this.lastOffset.x + (currentCoords.x - this.panStart.x),
+      y: this.lastOffset.y + (currentCoords.y - this.panStart.y),
+    }
+    this.redraw();
+  }
+
+  private stopPanning(): void {
+    this.mode = Mode.IDLE;
+    this.panStart = { x: 0, y: 0 };
+  }
+
+  // ************* DRAWING *************
   private startDrawing(e: MouseEvent | TouchEvent): void {
-    this.isDrawing = true;
+    if (this.mode !== Mode.IDLE) return;
+    this.mode = Mode.DRAWING;
     this.hasMoved = false;
     const coords = this.getCoordinates(e);
-    this.lastX = coords.x;
-    this.lastY = coords.y;
+    this.currentStroke = {
+      points: [coords],
+      color: this.ctx.strokeStyle,
+      width: this.ctx.lineWidth,
+    }
   }
 
   private draw(e: MouseEvent | TouchEvent): void {
-    if (!this.isDrawing) return;
+    if (this.mode !== Mode.DRAWING) return;
     this.hasMoved = true;
     const coords = this.getCoordinates(e);
     
-    this.ctx.beginPath();
-    this.ctx.moveTo(this.lastX, this.lastY);
-    this.ctx.lineTo(coords.x, coords.y);
-    this.ctx.stroke();
-
-    this.lastX = coords.x;
-    this.lastY = coords.y;
+    this.currentStroke?.points.push(coords);
+    this.redraw();
   }
 
   private stopDrawing(e: MouseEvent | TouchEvent): void {
-    if (this.isDrawing && !this.hasMoved) {
-      this.drawDot(e);
+    if (this.mode !== Mode.DRAWING) return;
+    if (this.currentStroke) {
+      this.strokes.push(this.currentStroke);
+      this.currentStroke = null;
     }
-    this.isDrawing = false;
+    this.redraw();
+    this.mode = Mode.IDLE;
   }
 
-  private drawDot(e: MouseEvent | TouchEvent): void {
-    const coords = this.getCoordinates(e);
-    this.ctx.beginPath();
-    this.ctx.arc(coords.x, coords.y, this.ctx.lineWidth / 2, 0, 2 * Math.PI);
-    this.ctx.fillStyle = this.ctx.strokeStyle;
-    this.ctx.fill();
-  }
-
+  // ************* UTILITIES *************
   private getCoordinates(e: MouseEvent | TouchEvent): Coordinates {
     const rect = this.canvas.getBoundingClientRect();
+    const event = e instanceof MouseEvent ? e : e.touches[0] || e.changedTouches[0];
     
-    if (e instanceof MouseEvent) {
-      return {
-        x: e.clientX - rect.left,
-        y: e.clientY - rect.top
-      };
-    } else {
-      // Touch event
-      const touch = e.touches[0] || e.changedTouches[0];
-      return {
-        x: touch.clientX - rect.left,
-        y: touch.clientY - rect.top
-      };
+    return {
+      x: event.clientX - rect.left - this.offset.x,
+      y: event.clientY - rect.top - this.offset.y,
+    };
+  }
+
+  private getAverageCoordinates(e: TouchEvent): Coordinates {
+    return {
+      x: e.touches[0].clientX + e.touches[1].clientX / 2,
+      y: e.touches[0].clientY + e.touches[1].clientY / 2,
     }
+  }
+
+  // ************* RENDERING *************
+  private redraw(): void {
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.save();
+    this.ctx.translate(this.offset.x, this.offset.y);
+
+    this.drawStrokes();
+
+    this.ctx.restore();
+  }
+
+  private drawStrokes(): void {
+    const allStrokes = this.currentStroke ? this.strokes.concat([this.currentStroke]) : this.strokes;
+    for (const stroke of allStrokes) {
+      this.ctx.strokeStyle = stroke.color;
+      this.ctx.lineWidth = stroke.width;
+      this.ctx.beginPath();
+      this.ctx.moveTo(stroke.points[0].x, stroke.points[0].y);
+      stroke.points.forEach(point => this.ctx.lineTo(point.x, point.y));
+      this.ctx.stroke();
+    };
   }
 }
 


### PR DESCRIPTION
Add panning to the canvas.

We do this by setting the app into distinct modes - `PANNING`, `DRAWING` or `IDLE` (This will help us implement the next phase, `ZOOMING`).

Offsetting is done by calculating the average movement of the two touch vectors, then adding that to the current offset.

When we draw each stroke, we save the coordinates with the current offset factored in. Then, when we pan, we translate the entire canvas, which updates the position through the 'viewport'.

We could potentially optimise this by going through each stroke and only rendering if it falls within the viewport.